### PR TITLE
[APP-1089] Upgrade Ruby to 2.6.5

### DIFF
--- a/geometry-in-ruby.gemspec
+++ b/geometry-in-ruby.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  # specify any dependencies here; for example:
-  # s.add_development_dependency "rspec"
+  s.add_development_dependency "minitest"
   # s.add_runtime_dependency "rest-client"
 end

--- a/geometry-in-ruby.gemspec
+++ b/geometry-in-ruby.gemspec
@@ -3,12 +3,13 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "geometry-in-ruby"
-  s.version     = '0.0.5'
+  s.version     = '0.0.6'
   s.authors     = ["Brandon Fosdick", "Meseker Yohannes"]
-  s.email       = ["meseker.yohannes@gmail.com"]
-  s.homepage    = "http://github.com/meseker/geometry"
+  s.email       = ["myohannes@aurorasolar.com"]
+  s.homepage    = "http://github.com/aurorasolar/geometry"
   s.summary     = %q{Geometric primitives and algoritms}
   s.description = %q{Geometric primitives and algorithms for Ruby}
+  s.required_ruby_version = "~> 2.6"
 
   s.rubyforge_project = "aurora_geometry"
 

--- a/lib/geometry/edge.rb
+++ b/lib/geometry/edge.rb
@@ -1,5 +1,3 @@
-require 'mathn'
-
 require_relative 'point'
 
 module Geometry
@@ -126,8 +124,8 @@ class Edge
 		    nil
 		end
 	    else
-		s = (-v1[1] * p.x + v1[0] * p.y) / denominator	# v1 x (p0 - p2) / denominator
-		t = ( v2[0] * p.y - v2[1] * p.x) / denominator	# v2 x (p0 - p2) / denominator
+		s = (-v1[1] * p.x + v1[0] * p.y).to_r / denominator	# v1 x (p0 - p2) / denominator
+		t = ( v2[0] * p.y - v2[1] * p.x).to_r / denominator	# v2 x (p0 - p2) / denominator
 
 		p0 + v1 * t if ((0..1) === s) && ((0..1) === t)
 	    end

--- a/lib/geometry/rectangle.rb
+++ b/lib/geometry/rectangle.rb
@@ -40,7 +40,7 @@ The {Rectangle} class cluster represents your typical arrangement of 4 corners a
 		@options = {} if !@options
 		@options
 	end
-	
+
 	# @overload new(width, height)
 	#   Creates a {Rectangle} of the given width and height, centered on the origin
 	#   @param [Number]   height  Height
@@ -125,7 +125,7 @@ The {Rectangle} class cluster represents your typical arrangement of 4 corners a
 	# @return [Point]   The {Rectangle}'s center
 	def center
 	    min, max = @points.minmax {|a,b| a.y <=> b.y}
-	    Point[(max.x+min.x)/2, (max.y+min.y)/2]
+	    Point[(max.x+min.x).to_r/2, (max.y+min.y).to_r/2]
 	end
 
 	# @return [Array<Edge>]   The {Rectangle}'s four edges (counterclockwise)


### PR DESCRIPTION
https://aurorasolar.atlassian.net/browse/APP-1089?atlOrigin=eyJpIjoiOWI3M2NkYzBjM2JiNDQyY2IzNDBiODFjMDE1MGQxOGEiLCJwIjoiaiJ9

This other PR needs to be merged first https://github.com/aurorasolar/geometry/pull/4

- This removes the `mathn` dependency as it was removed from Ruby