### PR TITLE
[APP-14459] Add Ruby 3 support

### DIFF
--- a/geometry-in-ruby.gemspec
+++ b/geometry-in-ruby.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/aurorasolar/geometry"
   s.summary     = %q{Geometric primitives and algoritms}
   s.description = %q{Geometric primitives and algorithms for Ruby}
-  s.required_ruby_version = "~> 2.6"
+  s.required_ruby_version = ">= 2.7.5", "< 3.2"
 
   s.rubyforge_project = "aurora_geometry"
 
@@ -17,6 +17,8 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
+
+  s.add_dependency "matrix", "< 1.0"
 
   s.add_development_dependency "minitest"
   # s.add_runtime_dependency "rest-client"

--- a/geometry-in-ruby.gemspec
+++ b/geometry-in-ruby.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "geometry-in-ruby"
-  s.version     = '0.0.6'
+  s.version     = '1.0.0'
   s.authors     = ["Brandon Fosdick", "Meseker Yohannes"]
   s.email       = ["myohannes@aurorasolar.com"]
   s.homepage    = "http://github.com/aurorasolar/geometry"


### PR DESCRIPTION
Jira: https://aurorasolar.atlassian.net/browse/APP-14459

* add support for Ruby `2.7`, `3.0`, and `3.1`
* remove support for Ruby `2.6`

All tests pass when run with Ruby versions `2.7.5`, `3.0.4`, and `3.1.2`. Is there anything else we should do to ensure this works?