### PR TITLE
chore: [APP-42383] downgrade required ruby version, version bump, GHA tests

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,21 @@
+name: Ruby
+
+on: [push]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ["3.0", "3.1", "3.2", "3.3", "3.4"]
+        os: [ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+      - run: bundle exec rake

--- a/geometry-in-ruby.gemspec
+++ b/geometry-in-ruby.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/aurorasolar/geometry"
   s.summary     = %q{Geometric primitives and algoritms}
   s.description = %q{Geometric primitives and algorithms for Ruby}
-  s.required_ruby_version = ">= 2.7.5"
+  s.required_ruby_version = ">= 2.0"
 
   s.rubyforge_project = "aurora_geometry"
 

--- a/geometry-in-ruby.gemspec
+++ b/geometry-in-ruby.gemspec
@@ -3,13 +3,13 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "geometry-in-ruby"
-  s.version     = '1.0.0'
+  s.version     = '2.0.0'
   s.authors     = ["Brandon Fosdick", "Meseker Yohannes"]
   s.email       = ["myohannes@aurorasolar.com"]
   s.homepage    = "http://github.com/aurorasolar/geometry"
   s.summary     = %q{Geometric primitives and algoritms}
   s.description = %q{Geometric primitives and algorithms for Ruby}
-  s.required_ruby_version = ">= 2.7.5"
+  s.required_ruby_version = ">= 2.0"
 
   s.rubyforge_project = "aurora_geometry"
 

--- a/geometry-in-ruby.gemspec
+++ b/geometry-in-ruby.gemspec
@@ -3,13 +3,13 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "geometry-in-ruby"
-  s.version     = '2.0.0'
+  s.version     = '1.1.0'
   s.authors     = ["Brandon Fosdick", "Meseker Yohannes"]
   s.email       = ["myohannes@aurorasolar.com"]
   s.homepage    = "http://github.com/aurorasolar/geometry"
   s.summary     = %q{Geometric primitives and algoritms}
   s.description = %q{Geometric primitives and algorithms for Ruby}
-  s.required_ruby_version = ">= 2.0"
+  s.required_ruby_version = ">= 2.7.5"
 
   s.rubyforge_project = "aurora_geometry"
 


### PR DESCRIPTION
Downgrade required ruby version in attempt to fix `geometry-in-ruby-1.0.0 requires ruby version >= 2.7.5, < 3.2` encountered during `backend` ruby upgrade